### PR TITLE
Add configuration file for lombok to filter methods generated by lombok from code coverage report

### DIFF
--- a/app/src/main/java/com/parasoft/demoapp/retrofitConfig/lombok.config
+++ b/app/src/main/java/com/parasoft/demoapp/retrofitConfig/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
Here are the explanations for the properties:
- config.stopBubbling = true tells Lombok that this is your root directory and that it should not search parent directories for more configuration files (you can have more than one lombok config files in different directories/packages).
- lombok.addLombokGeneratedAnnotation = true will add @lombok.Generated annotation to all Lombok generated methods.

I tried overriding "toString()" method in "ForgotPasswordUserInfo" and seems it won't be filtered out, which meets our needs.
![image](https://user-images.githubusercontent.com/35082985/190278468-a353ae9c-0084-4c56-8ff6-d208a345cbcc.png)

And here's a screenshot of updated coverage:
![image](https://user-images.githubusercontent.com/35082985/190278603-274fa136-7b42-4aba-8811-6205f583fd96.png)

Feel free to move the config file to upper/deeper directory where you think make more sense.

